### PR TITLE
Fix broken links in the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ### Checklist
 
-* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
-* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
+* [ ] I have read the [Contributor Guide](CONTRIBUTING.md)
+* [ ] I have read and agree to the [Code of Conduct](CODE_OF_CONDUCT.md)
 * [ ] I have added a description of my changes and why I'd like them included in the section below
 
 ### Description of Changes


### PR DESCRIPTION
Paths are relative to the PR url, not the source directory, so these were going to the organization rather than the repo.

### Checklist

* [ ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Describe your changes here

### Related Issues

List related issues here
